### PR TITLE
Feature: No failed Travis-CI builds

### DIFF
--- a/github_api/prs.py
+++ b/github_api/prs.py
@@ -135,7 +135,8 @@ def has_build_passed(api, statuses_url):
 
     if statuses:
         for status in statuses:
-            if (status["state"] is "success") and (status["description"] is "The Travis CI build passed"):
+            if (status["state"] is "success") and \
+            (status["description"] is "The Travis CI build passed"):
                 return True
     return False
 


### PR DESCRIPTION
If a pull request failed to pass a Travis-CI build, or tests, then do not treat it as a ready PR.

This PR _should_ reduce the amount broken merged chaos builds, syntax errors, and changes that break unit tests.